### PR TITLE
Wrong charset used in creating search terms when server supports UTF8

### DIFF
--- a/mail/src/main/java/com/sun/mail/imap/protocol/IMAPProtocol.java
+++ b/mail/src/main/java/com/sun/mail/imap/protocol/IMAPProtocol.java
@@ -2476,7 +2476,7 @@ public class IMAPProtocol extends Protocol {
 	// is not allowed; see RFC 6855, section 3, last paragraph)
 	if (supportsUtf8() || SearchSequence.isAscii(term)) {
 	    try {
-		return issueSearch(msgSequence, term, null);
+		return issueSearch(msgSequence, term, supportsUtf8() ? StandardCharsets.UTF_8.name() : null);
 	    } catch (IOException ioex) { /* will not happen */ }
 	}
 
@@ -2537,7 +2537,7 @@ public class IMAPProtocol extends Protocol {
 
 	Response[] r;
 
-	if (charset == null) // text is all US-ASCII
+	if (charset == null || (StandardCharsets.UTF_8.name().equalsIgnoreCase(charset) && supportsUtf8())) // text is all US-ASCII
 	    r = command("SEARCH", args);
 	else
 	    r = command("SEARCH CHARSET " + charset, args);


### PR DESCRIPTION
there is a bug ,when i search subject with Chinese character such as “OA系统”.  The log print :[https://github.com/ZhongXiaoHong/mail/blob/master/bad_comand.txt](url)
The reason for this is that  the Chinese character  “OA系统” is  regarded as  ASSCII  when the  program  get the byte array.
see the source code:  com.sun.mail.imap.protocol.SearchSequence#subject(SubjectTerm term, String charset)
` protected Argument subject(SubjectTerm term, String charset) throws SearchException, IOException {
        Argument result = new Argument();
        result.writeAtom("SUBJECT");
        result.writeString(term.getPattern(), charset);
        return result;
    }`

com.sun.mail.iap.Argument#writeString(java.lang.String, java.lang.String)

` public Argument writeString(String s, String charset) throws UnsupportedEncodingException {
        if (charset == null) {
            this.writeString(s);
        } else {
            this.items.add(new AString(s.getBytes(charset)));
        }
        return this;
    }`

com.sun.mail.iap.Argument#writeString(java.lang.String)

`public Argument writeString(String s) {
        this.items.add(new AString(ASCIIUtility.getBytes(s)));
        return this;
    }`