### PR TITLE
Using service loader mediator annotations (see #630).

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -116,6 +116,18 @@
             <artifactId>angus-activation</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>biz.aQute.bnd</groupId>
+            <artifactId>biz.aQute.bnd.annotation</artifactId>
+            <version>6.3.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.annotation</artifactId>
+            <version>8.1.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -359,10 +371,6 @@
                         <Implementation-Title>${project.name}</Implementation-Title>
                         <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
                         <Implementation-Build-Id>${buildNumber}</Implementation-Build-Id>
-                        <Import-Package>
-                            !org.glassfish.hk2.osgiresourcelocator,
-                            *
-                        </Import-Package>
                     </instructions>
                 </configuration>
                 <executions>

--- a/api/src/main/java/jakarta/mail/Session.java
+++ b/api/src/main/java/jakarta/mail/Session.java
@@ -198,6 +198,7 @@ import jakarta.mail.util.StreamProvider;
  * @author Max Spivak
  */
 
+@aQute.bnd.annotation.spi.ServiceConsumer(value = Provider.class)
 public final class Session {
 
 	// Support legacy @DefaultProvider

--- a/api/src/main/java/jakarta/mail/util/FactoryFinder.java
+++ b/api/src/main/java/jakarta/mail/util/FactoryFinder.java
@@ -54,13 +54,6 @@ class FactoryFinder {
             return factory;
         }
 
-        // handling Glassfish/OSGi (platform specific default)
-        if (isOsgi()) {
-            T result = lookupUsingOSGiServiceLoader(factoryId);
-            if (result != null) {
-                return result;
-            }
-        }
         throw new IllegalStateException("Not provider of " + factoryClass.getName() + " was found");
     }
 
@@ -84,33 +77,6 @@ class FactoryFinder {
     private static String fromSystemProperty(String factoryId) {
         String systemProp = System.getProperty(factoryId);
         return systemProp;
-    }
-
-    private static final String OSGI_SERVICE_LOADER_CLASS_NAME = "org.glassfish.hk2.osgiresourcelocator.ServiceLoader";
-
-    private static boolean isOsgi() {
-        try {
-            Class.forName(OSGI_SERVICE_LOADER_CLASS_NAME);
-            return true;
-        } catch (ClassNotFoundException ignored) {
-        }
-        return false;
-    }
-
-    @SuppressWarnings({"unchecked"})
-    private static <T> T lookupUsingOSGiServiceLoader(String factoryId) {
-        try {
-            // Use reflection to avoid having any dependency on HK2 ServiceLoader class
-            Class<?> serviceClass = Class.forName(factoryId);
-            Class<?>[] args = new Class<?>[]{serviceClass};
-            Class<?> target = Class.forName(OSGI_SERVICE_LOADER_CLASS_NAME);
-            Method m = target.getMethod("lookupProviderInstances", Class.class);
-            Iterator<?> iter = ((Iterable<?>) m.invoke(null, (Object[]) args)).iterator();
-            return iter.hasNext() ? (T) iter.next() : null;
-        } catch (Exception ignored) {
-            // log and continue
-            return null;
-        }
     }
 
     private static <T> T factoryFromServiceLoader(Class<T> factory) {

--- a/api/src/main/java/jakarta/mail/util/StreamProvider.java
+++ b/api/src/main/java/jakarta/mail/util/StreamProvider.java
@@ -31,6 +31,7 @@ import java.util.ServiceLoader;
  *
  * @since JavaMail 2.1
  */
+@aQute.bnd.annotation.spi.ServiceConsumer(value = StreamProvider.class)
 public interface StreamProvider {
 
 	/**

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -29,4 +29,6 @@ module jakarta.mail {
     uses jakarta.mail.util.StreamProvider;
     //reflective call to java.beans.Beans.instantiate
     requires static java.desktop;
+    //annotations for OSGi service loader mediator
+    requires static biz.aQute.bnd.annotation;
 }


### PR DESCRIPTION
Shows the usage of the [service locator mediator](https://github.com/eclipse-ee4j/mail/issues/630) with annotations that generate the "Require-Capability" header in MANIFEST.MF. (Alternatively the Header can be specified directly in pom.xml.)

The Providers (in angus-mail) need a corresponding `@ServiceProvider` annotation such as:
```
@aQute.bnd.annotation.spi.ServiceProvider(value = StreamProvider.class)
public class MailStreamProvider implements StreamProvider {
```

(Sorry, can't provide a PR for that, maven compilation for angus-mail doesn't work.)