### PR TITLE
#629: jakarta.mail-api-2.1.0.jar does not work in OSGi environment (hk2servicelocator)

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -363,6 +363,7 @@
                         <Implementation-Title>${project.name}</Implementation-Title>
                         <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
                         <Implementation-Build-Id>${buildNumber}</Implementation-Build-Id>
+                        <DynamicImport-Package>org.glassfish.hk2.osgiresourcelocator</DynamicImport-Package>
                         <Import-Package>
                             !org.glassfish.hk2.osgiresourcelocator,
                             *

--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -21,7 +21,10 @@ longer available.
 
 		  CHANGES IN THE 2.1.2 RELEASE
           ----------------------------
+E  629  jakarta.mail-api-2.1.0.jar does not work in OSGi environment (hk2servicelocator)
 E  660  jakarta.mail-api is not a Multi Release JAR
+E  664  Typo in Session.setDebug Javadoc
+
 
 		  CHANGES IN THE 2.1.1 RELEASE
 		  ----------------------------


### PR DESCRIPTION
fixes #629 