### PR TITLE
SharedFileInputStream should comply with spec

### DIFF
--- a/api/src/main/java/jakarta/mail/util/SharedFileInputStream.java
+++ b/api/src/main/java/jakarta/mail/util/SharedFileInputStream.java
@@ -82,13 +82,13 @@ public class SharedFileInputStream extends BufferedInputStream
      * True if this is a top level stream created directly by "new".
      * False if this is a derived stream created by newStream.
      */
-    private boolean master = true;
+    private boolean root = true;
 
     /**
      * Reference to the top level stream in order not to be junked by garbage collection when there is a remaining derived stream.
      * null if this is a top level stream
      */
-    private SharedFileInputStream masterInputStream = null;
+    private SharedFileInputStream rootInputStream = null;
 
     /**
      * A shared class that keeps track of the references
@@ -217,11 +217,11 @@ public class SharedFileInputStream extends BufferedInputStream
     /**
      * Used internally by the <code>newStream</code> method.
      */
-    private SharedFileInputStream(SharedFileInputStream masterInputStream, SharedFile sf, long start, long len,
+    private SharedFileInputStream(SharedFileInputStream rootInputStream, SharedFile sf, long start, long len,
                                   int bufsize) {
         super(null);
-        this.masterInputStream = masterInputStream;
-        this.master = false;
+        this.rootInputStream = rootInputStream;
+        this.root = false;
         this.sf = sf;
         this.in = sf.open();
         this.start = start;
@@ -472,7 +472,7 @@ public class SharedFileInputStream extends BufferedInputStream
         if (in == null)
             return;
         try {
-            if (master)
+            if (root)
                 sf.forceClose();
             else
                 sf.close();
@@ -519,14 +519,14 @@ public class SharedFileInputStream extends BufferedInputStream
         if (end == -1)
             end = datalen;
 
-        SharedFileInputStream masterIs;
+        SharedFileInputStream rootIs;
 
-        if (this.master)
-            masterIs = this;
+        if (this.root)
+            rootIs = this;
         else
-            masterIs = this.masterInputStream;
+            rootIs = this.rootInputStream;
 
-        return new SharedFileInputStream(masterIs, sf,
+        return new SharedFileInputStream(rootIs, sf,
                 this.start + start, end - start, bufsize);
     }
 

--- a/api/src/main/java/jakarta/mail/util/SharedFileInputStream.java
+++ b/api/src/main/java/jakarta/mail/util/SharedFileInputStream.java
@@ -35,15 +35,6 @@ import java.lang.ref.Reference;
  * A <code>RandomAccessFile</code> object is used to
  * access the file data. <p>
  *
- * Note that when the SharedFileInputStream is closed,
- * all streams created with the <code>newStream</code>
- * method are also closed.  This allows the creator of the
- * SharedFileInputStream object to control access to the
- * underlying file and ensure that it is closed when
- * needed, to avoid leaking file descriptors.  Note also
- * that this behavior contradicts the requirements of
- * SharedInputStream and may change in a future release.
- *
  * @author Bill Shannon
  * @since JavaMail 1.4
  */

--- a/api/src/main/java/jakarta/mail/util/SharedFileInputStream.java
+++ b/api/src/main/java/jakarta/mail/util/SharedFileInputStream.java
@@ -480,6 +480,7 @@ public class SharedFileInputStream extends BufferedInputStream
             sf = null;
             in = null;
             buf = null;
+            rootInputStream = null;
         }
     }
 

--- a/api/src/main/java/jakarta/mail/util/SharedFileInputStream.java
+++ b/api/src/main/java/jakarta/mail/util/SharedFileInputStream.java
@@ -23,7 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
-import java.lang.ref.Reference;
+import java.util.Objects;
 
 /**
  * A <code>SharedFileInputStream</code> is a
@@ -441,7 +441,7 @@ public class SharedFileInputStream extends BufferedInputStream
             sf = null;
             in = null;
             buf = null;
-            Reference.reachabilityFence(this);
+            Objects.requireNonNull(this); //TODO: replace with Reference.reachabilityFence
         }
     }
 
@@ -485,7 +485,7 @@ public class SharedFileInputStream extends BufferedInputStream
             return new SharedFileInputStream(sf,
                     this.start + start, end - start, bufsize);
         } finally {
-            Reference.reachabilityFence(this);
+            Objects.requireNonNull(this); //TODO: replace with Reference.reachabilityFence
         }
     }
 

--- a/api/src/test/java/jakarta/mail/util/SharedFileInputStreamTest.java
+++ b/api/src/test/java/jakarta/mail/util/SharedFileInputStreamTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
 package jakarta.mail.util;
 
 import org.junit.Test;
@@ -9,6 +25,19 @@ import java.io.InputStream;
 import static org.junit.Assert.fail;
 
 public class SharedFileInputStreamTest {
+
+    @Test
+    public void testChild() throws Exception {
+        File file = File.createTempFile("test", "test");
+
+        try (InputStream childStream = new SharedFileInputStream(file).newStream(0, -1)) {
+            System.gc();
+            childStream.read();
+        } catch (IOException e) {
+            fail("IOException is not expected");
+        }
+    }
+
 
     @Test
     public void testGrandChild() throws Exception {

--- a/api/src/test/java/jakarta/mail/util/SharedFileInputStreamTest.java
+++ b/api/src/test/java/jakarta/mail/util/SharedFileInputStreamTest.java
@@ -24,6 +24,14 @@ import java.io.InputStream;
 
 import static org.junit.Assert.fail;
 
+/**
+ * Please note:
+ * In version 2.1.2 Final Release, a difference in test results was observed based on the choice of assertion method.
+ * Invoking stream.read() directly yielded distinct outcomes compared to using Assertions.assertDoesNotThrow() from JUnit 5.
+ * This divergence is likely attributed to scope of the code.
+ * After the patch, this issue did not reoccur. However, it remains essential to be attentive
+ * If any changes are deemed necessary, please ensure a comprehensive review and thorough testing to uphold the original behavior.
+ */
 public class SharedFileInputStreamTest {
 
     @Test

--- a/api/src/test/java/jakarta/mail/util/SharedFileInputStreamTest.java
+++ b/api/src/test/java/jakarta/mail/util/SharedFileInputStreamTest.java
@@ -28,26 +28,30 @@ public class SharedFileInputStreamTest {
 
     @Test
     public void testChild() throws Exception {
-        File file = File.createTempFile("test", "test");
+        File file = File.createTempFile(SharedFileInputStreamTest.class.getName(), "testChild");
 
         try (InputStream childStream = new SharedFileInputStream(file).newStream(0, -1)) {
             System.gc();
             childStream.read();
         } catch (IOException e) {
             fail("IOException is not expected");
+        } finally {
+            file.delete();
         }
     }
 
 
     @Test
     public void testGrandChild() throws Exception {
-        File file = File.createTempFile("test", "test");
+        File file = File.createTempFile(SharedFileInputStreamTest.class.getName(), "testGrandChild");
 
         try (InputStream grandChild = ((SharedFileInputStream) new SharedFileInputStream(file).newStream(0, -1)).newStream(0, -1)) {
             System.gc();
             grandChild.read();
         } catch (IOException e) {
             fail("IOException is not expected");
+        } finally {
+            file.delete();
         }
     }
 }

--- a/api/src/test/java/jakarta/mail/util/SharedFileInputStreamTest.java
+++ b/api/src/test/java/jakarta/mail/util/SharedFileInputStreamTest.java
@@ -1,0 +1,24 @@
+package jakarta.mail.util;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.fail;
+
+public class SharedFileInputStreamTest {
+
+    @Test
+    public void testGrandChild() throws Exception {
+        File file = File.createTempFile("test", "test");
+
+        try (InputStream grandChild = ((SharedFileInputStream) new SharedFileInputStream(file).newStream(0, -1)).newStream(0, -1)) {
+            System.gc();
+            grandChild.read();
+        } catch (IOException e) {
+            fail("IOException is not expected");
+        }
+    }
+}

--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -19,6 +19,11 @@ Bug IDs that start with "G" can be found in the GlassFish Issue Tracker
 Seven digit bug numbers are from the old Sun bug database, which is no
 longer available.
 
+          CHANGES IN THE 2.1.3 RELEASE
+          ----------------------------
+E  695  SharedFileInputStream should comply with spec
+
+
 		  CHANGES IN THE 2.1.2 RELEASE
           ----------------------------
 E  629  jakarta.mail-api-2.1.0.jar does not work in OSGi environment (hk2servicelocator)

--- a/www/docs/COMPAT.txt
+++ b/www/docs/COMPAT.txt
@@ -4,6 +4,15 @@
 		    Jakarta Mail API 2.0.1 release
 		    ------------------------------
 
+-- Jakarta Mail 2.1.3 --
+
+- SharedFileInputStream should comply with spec
+
+    The root SharedFileInputStream no longer closes all streams
+    created with the newStream. This behavior was not compliant with
+    the contract specified in the SharedInputStream interface
+    which specifies that all streams must be closed before the shared resource is closed.
+
 -- Jakarta Mail 2.0.0 --
 
 The Jakarta Mail 2.0 specification is the successor of the Jakarta


### PR DESCRIPTION
resolves #694 

Added reference to master `SharedFileInputStream` to slaves.

By doing this, I guess it can retain reference to master `SharedFileInputStream` in order not to be junked by garbage collection until the reference to the last derived stream is gone.

Feel free to comment if there are some points to add or fix.