### PR TITLE
ISSUE-721 - add full Markdown for URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,26 +7,26 @@ Thanks for your interest in this project.
 Jakarta Mail™ defines a platform-independent and protocol-independent
 framework to build mail and messaging applications.
 
-* https://projects.eclipse.org/projects/ee4j.mail
+* [https://projects.eclipse.org/projects/ee4j.mail](https://projects.eclipse.org/projects/ee4j.mail)
 
 ## Terms of Use
 
 This repository is subject to the Terms of Use of the Eclipse Foundation
 
-* http://www.eclipse.org/legal/termsofuse.php
+* [http://www.eclipse.org/legal/termsofuse.php](http://www.eclipse.org/legal/termsofuse.php)
 
 ## Developer resources
 
 Information regarding source code management, builds, coding standards, and
 more.
 
-* https://projects.eclipse.org/projects/ee4j.mail/developer
+* [https://projects.eclipse.org/projects/ee4j.mail/developer](https://projects.eclipse.org/projects/ee4j.mail/developer)
 
 The project maintains the following source code repositories
 
-* https://github.com/jakartaee/mail-api
-* https://github.com/jakartaee/mail-tck
-* https://github.com/jakartaee/mail-spec
+* [https://github.com/jakartaee/mail-api](https://github.com/jakartaee/mail-api)
+* [https://github.com/jakartaee/mail-tck](https://github.com/jakartaee/mail-tck)
+* [https://github.com/jakartaee/mail-spec](https://github.com/jakartaee/mail-spec)
 
 ## Eclipse Development Process
 
@@ -38,17 +38,17 @@ Process (JESP) in accordance with the Eclipse Foundation Specification Process
 v1.2 (EFSP) to ensure that the specification process is complied with by all
 Jakarta EE specification projects.
 
-* https://eclipse.org/projects/dev_process
-* https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf
-* https://jakarta.ee/about/jesp/
-* https://www.eclipse.org/legal/efsp_non_assert.php
+* [https://eclipse.org/projects/dev_process](https://eclipse.org/projects/dev_process)
+* [https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf](https://www.eclipse.org/org/documents/Eclipse_IP_Policy.pdf)
+* [https://jakarta.ee/about/jesp/](https://jakarta.ee/about/jesp/)
+* [https://www.eclipse.org/legal/efsp_non_assert.php](https://www.eclipse.org/legal/efsp_non_assert.php)
 
 ## Eclipse Contributor Agreement
 
 In order to be able to contribute to Eclipse Foundation projects you must
 electronically sign the Eclipse Contributor Agreement (ECA).
 
-* http://www.eclipse.org/legal/ECA.php
+* [http://www.eclipse.org/legal/ECA.php](http://www.eclipse.org/legal/ECA.php)
 
 The ECA provides the Eclipse Foundation with a permanent record that you agree
 that each of your contributions will comply with the commitments documented in
@@ -57,10 +57,10 @@ the email address matching the "Author" field of your contribution's Git commits
 fulfills the DCO's requirement that you sign-off on your contributions.
 
 For more information, please see the Eclipse Committer Handbook:
-https://www.eclipse.org/projects/handbook/#resources-commit
+[https://www.eclipse.org/projects/handbook/#resources-commit](https://www.eclipse.org/projects/handbook/#resources-commit)
 
 ## Contact
 
 Contact the project developers via the project's "dev" list.
 
-* https://accounts.eclipse.org/mailing-list/mail-dev
+* [https://accounts.eclipse.org/mailing-list/mail-dev](https://accounts.eclipse.org/mailing-list/mail-dev)

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -2,7 +2,7 @@
 
 This content is produced and maintained by the Jakarta Mail project.
 
-* Project home: https://projects.eclipse.org/projects/ee4j.mail
+* Project home: [https://projects.eclipse.org/projects/ee4j.mail](https://projects.eclipse.org/projects/ee4j.mail)
 
 ## Trademarks
 
@@ -18,11 +18,11 @@ source code repository logs.
 
 This program and the accompanying materials are made available under the terms
 of the Eclipse Public License v. 2.0 which is available at
-https://www.eclipse.org/legal/epl-2.0. This Source Code may also be made
+[https://www.eclipse.org/legal/epl-2.0](https://www.eclipse.org/legal/epl-2.0). This Source Code may also be made
 available under the following Secondary Licenses when the conditions for such
 availability set forth in the Eclipse Public License v. 2.0 are satisfied:
 (secondary) GPL-2.0 with Classpath-exception-2.0 which is available at
-https://openjdk.java.net/legal/gplv2+ce.html.
+[https://openjdk.java.net/legal/gplv2+ce.html](https://openjdk.java.net/legal/gplv2+ce.html).
 
 SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0
 
@@ -30,9 +30,9 @@ SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0
 
 The project maintains the following source code repositories:
 
-* https://github.com/jakartaee/mail-api
-* https://github.com/jakartaee/mail-tck
-* https://github.com/jakartaee/mail-spec
+* [https://github.com/jakartaee/mail-api](https://github.com/jakartaee/mail-api)
+* [https://github.com/jakartaee/mail-tck](https://github.com/jakartaee/mail-tck)
+* [https://github.com/jakartaee/mail-spec](https://github.com/jakartaee/mail-spec)
 
 ## Third-party Content
 
@@ -65,8 +65,8 @@ normalize.css (3.0.2)
 SigTest (4.0)
 
 * License: (GPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)
-* Project: https://wiki.openjdk.java.net/display/CodeTools/sigtest
-* Source: http://hg.openjdk.java.net/code-tools/sigtest/file/c57f97e2ac2f
+* Project: [https://wiki.openjdk.java.net/display/CodeTools/sigtest](https://wiki.openjdk.java.net/display/CodeTools/sigtest)
+* Source: [http://hg.openjdk.java.net/code-tools/sigtest/file/c57f97e2ac2f](http://hg.openjdk.java.net/code-tools/sigtest/file/c57f97e2ac2f)
 
 ## Cryptography
 


### PR DESCRIPTION
add full Markdown for URLs since Jekyll action doesn't autolink them like GitHub Pages does