### PR TITLE
#708 Add missing javadoc for supporting ServiceLoader mechanism

### DIFF
--- a/api/src/main/java/jakarta/mail/Provider.java
+++ b/api/src/main/java/jakarta/mail/Provider.java
@@ -18,7 +18,10 @@ package jakarta.mail;
 
 /**
  * The Provider is a class that describes a protocol
- * implementation.  The values typically come from the
+ * implementation.  The {@link Session} supports
+ * configuring providers using the Java SE
+ * {@link java.util.ServiceLoader ServiceLoader} mechanism.
+ * As an alternative the values could come from the
  * javamail.providers and javamail.default.providers
  * resource files.  An application may also create and
  * register a Provider object to dynamically add support
@@ -26,6 +29,7 @@ package jakarta.mail;
  *
  * @author Max Spivak
  * @author Bill Shannon
+ * @see Session
  */
 public class Provider {
 


### PR DESCRIPTION
I have added the missing Javadoc to the Provider class to fix #708