### PR TITLE
Fix inconsistent mail message content id property

### DIFF
--- a/api/src/main/java/jakarta/mail/internet/MimeBodyPart.java
+++ b/api/src/main/java/jakarta/mail/internet/MimeBodyPart.java
@@ -366,7 +366,7 @@ public class MimeBodyPart extends BodyPart implements MimePart {
      */
     @Override
     public String getContentID() throws MessagingException {
-        return getHeader("Content-Id", null);
+        return getHeader("Content-ID", null);
     }
 
     /**


### PR DESCRIPTION
**Description**
Fix inconsistent header capitalization between getContentID() and setContentID() methods in MimeBodyPart.

**Problem**
The getter and setter methods used different capitalizations for the Content-ID header:
- `setContentID()` uses "Content-ID" (uppercase 'D') 
- `getContentID()` uses "Content-Id" (lowercase 'd')