### PR TITLE
Fix Inconsistent between getContentId and SetContentId methods

### DIFF
--- a/api/src/main/java/jakarta/mail/internet/MimeBodyPart.java
+++ b/api/src/main/java/jakarta/mail/internet/MimeBodyPart.java
@@ -366,7 +366,7 @@ public class MimeBodyPart extends BodyPart implements MimePart {
      */
     @Override
     public String getContentID() throws MessagingException {
-        return getHeader("Content-Id", null);
+        return getHeader("Content-ID", null);
     }
 
     /**


### PR DESCRIPTION
**Description**
Fixing naming convention in getContentID()#MimeBodyPart.
`
//Previous
public String getContentID() throws MessagingException {
        return getHeader("Content-Id", null);     //lowercase 'd'
    }

//Now   
public String getContentID() throws MessagingException {
        return getHeader("Content-ID", null); //uppercase 'D'
    }

`