### PR TITLE
Handle comments in angled address specs in InternetAddress.parse()

### DIFF
--- a/api/src/main/java/jakarta/mail/internet/InternetAddress.java
+++ b/api/src/main/java/jakarta/mail/internet/InternetAddress.java
@@ -885,6 +885,22 @@ public class InternetAddress extends Address implements Cloneable {
                             case '"':
                                 inquote = !inquote;
                                 break;
+                            case '(':
+                                if (!inquote) {
+                                    // Skip comment inside angled address (same logic as main parser)
+                                    for (index++, nesting = 1; index < length && nesting > 0; index++) {
+                                        char cc = s.charAt(index);
+                                        if (cc == '\\') {
+                                            index++; // skip escaped char
+                                        } else if (cc == '(') {
+                                            nesting++;
+                                        } else if (cc == ')') {
+                                            nesting--;
+                                        }
+                                    }
+                                    index--; // point to closing paren
+                                }
+                                break;
                             case '>':
                                 if (inquote)
                                     continue;


### PR DESCRIPTION
InternetAddress.parse() fails to handle comments (text) within angled address specifications <email@domain.com (comment)>. The main parsing loop correctly skips comments, but the angled address parser (inside case '<':) lacks comment handling, causing comments to be treated as part of the email address.


Fix: Add comment parsing logic to the angled address parser, mirroring the existing comment handling in the main parsing loop. This ensures comments within < > are properly skipped and not included in the final email address.

