### PR TITLE
Improve MimeMessage UTF8 handling backport

### DIFF
--- a/api/src/main/java/jakarta/mail/internet/MimeMessage.java
+++ b/api/src/main/java/jakarta/mail/internet/MimeMessage.java
@@ -63,9 +63,9 @@ import java.util.Properties;
  * MimeMessage uses the <code>InternetHeaders</code> class to parse and
  * store the top level RFC 822 headers of a message. <p>
  *
- * The <code>mail.mime.address.strict</code> session property controls
- * the parsing of address headers.  By default, strict parsing of address
- * headers is done.  If this property is set to <code>"false"</code>,
+ * The <code>mail.mime.address.strict</code> session or system property
+ * controls the parsing of address headers.  By default, strict parsing
+ * of address headers is done. If this property is set to <code>"false"</code>,
  * strict parsing is not done and many illegal addresses that sometimes
  * occur in real messages are allowed.  See the <code>InternetAddress</code>
  * class for details.

--- a/api/src/main/java/jakarta/mail/internet/MimeMessage.java
+++ b/api/src/main/java/jakarta/mail/internet/MimeMessage.java
@@ -2318,4 +2318,13 @@ public class MimeMessage extends Message implements MimePart {
             throws MessagingException {
         return new MimeMessage(session);
     }
+
+    boolean isStrict() {
+        return strict;
+    }
+
+    boolean isAllowutf8() {
+        return allowutf8;
+    }
+
 }

--- a/api/src/main/java/jakarta/mail/internet/MimeMessage.java
+++ b/api/src/main/java/jakarta/mail/internet/MimeMessage.java
@@ -190,7 +190,7 @@ public class MimeMessage extends Message implements MimePart {
         modified = true;
         headers = new InternetHeaders();
         flags = new Flags();    // empty flags object
-        initStrict();
+        initConfiguration();
     }
 
     /**
@@ -210,7 +210,7 @@ public class MimeMessage extends Message implements MimePart {
             throws MessagingException {
         super(session);
         flags = new Flags(); // empty Flags object
-        initStrict();
+        initConfiguration();
         parse(is);
         saved = true;
     }
@@ -240,6 +240,7 @@ public class MimeMessage extends Message implements MimePart {
             bos = new ByteArrayOutputStream();
         try {
             strict = source.strict;
+            allowutf8 = source.allowutf8;
             source.writeTo(bos);
             bos.close();
             try (InputStream bis = getStreamProvider().inputSharedByteArray(bos.toByteArray())) {
@@ -266,7 +267,7 @@ public class MimeMessage extends Message implements MimePart {
         super(folder, msgnum);
         flags = new Flags();  // empty Flags object
         saved = true;
-        initStrict();
+        initConfiguration();
     }
 
     /**
@@ -285,7 +286,7 @@ public class MimeMessage extends Message implements MimePart {
     protected MimeMessage(Folder folder, InputStream is, int msgnum)
             throws MessagingException {
         this(folder, msgnum);
-        initStrict();
+        initConfiguration();
         parse(is);
     }
 
@@ -306,18 +307,16 @@ public class MimeMessage extends Message implements MimePart {
         this(folder, msgnum);
         this.headers = headers;
         this.content = content;
-        initStrict();
+        initConfiguration();
     }
 
     /**
-     * Set the strict flag based on property.
+     * Set the configuration based on the session properties or system properties if no session is set.
      */
-    private void initStrict() {
-        if (session != null) {
-            Properties props = session.getProperties();
-            strict = MimeUtility.getBooleanProperty(props, "mail.mime.address.strict", true);
-            allowutf8 = MimeUtility.getBooleanProperty(props, "mail.mime.allowutf8", false);
-        }
+    private void initConfiguration() {
+        Properties props = session != null ? session.getProperties() : System.getProperties();
+        strict = MimeUtility.getBooleanProperty(props, "mail.mime.address.strict", true);
+        allowutf8 = MimeUtility.getBooleanProperty(props, "mail.mime.allowutf8", false);
     }
 
     /**

--- a/api/src/main/java/jakarta/mail/internet/package-info.java
+++ b/api/src/main/java/jakarta/mail/internet/package-info.java
@@ -29,6 +29,8 @@
  * The Jakarta Mail API supports the following standard properties,
  * which may be set in the <code>Session</code> object, or in the
  * <code>Properties</code> object used to create the <code>Session</code> object.
+ * The {@link jakarta.mail.internet.MimeMessage MimeMessage} falls back to
+ * System properties when created without a <code>Session</code> object.
  * The properties are always set as strings; the Type column describes
  * how the string is interpreted.  For example, use
  * </P>
@@ -51,7 +53,7 @@
  * <TD><A ID="mail.mime.address.strict">mail.mime.address.strict</A></TD>
  * <TD>boolean</TD>
  * <TD>
- * The <code>mail.mime.address.strict</code> session property controls
+ * The <code>mail.mime.address.strict</code> property controls
  * the parsing of address headers.  By default, strict parsing of address
  * headers is done.  If this property is set to <code>"false"</code>,
  * strict parsing is not done and many illegal addresses that sometimes

--- a/api/src/test/java/jakarta/mail/internet/MimeMessageTest.java
+++ b/api/src/test/java/jakarta/mail/internet/MimeMessageTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2025 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package jakarta.mail.internet;
+
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Properties;
+import jakarta.mail.Session;
+import org.junit.Test;
+
+/**
+ * Test the properties that control strict address parsing and UTF-8 support
+ */
+public class MimeMessageTest {
+
+    @Test
+    public void testDefaultProperties() throws Exception {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage message = new MimeMessage(session);
+        assertEquals(true, message.isStrict());
+        assertEquals(false, message.isAllowutf8());
+    }
+
+    @Test
+    public void testSystemAndSession() throws Exception {
+        try {
+            System.setProperty("mail.mime.address.strict", Boolean.TRUE.toString());
+            System.setProperty("mail.mime.allowutf8", Boolean.FALSE.toString());
+            Properties properties = new Properties();
+            properties.setProperty("mail.mime.address.strict", Boolean.FALSE.toString());
+            properties.setProperty("mail.mime.allowutf8", Boolean.TRUE.toString());
+            Session session = Session.getInstance(properties);
+            MimeMessage message = new MimeMessage(session);
+            assertEquals(false, message.isStrict());
+            assertEquals(true, message.isAllowutf8());
+        } finally {
+            System.clearProperty("mail.mime.address.strict");
+            System.clearProperty("mail.mime.allowutf8");
+        }
+    }
+
+    @Test
+    public void testSystemPropertiesNoSession() throws Exception {
+        try {
+            System.setProperty("mail.mime.address.strict", Boolean.FALSE.toString());
+            System.setProperty("mail.mime.allowutf8", Boolean.TRUE.toString());
+            MimeMessage message = new MimeMessage((Session) null);
+            assertEquals(false, message.isStrict());
+            assertEquals(true, message.isAllowutf8());
+        } finally {
+            System.clearProperty("mail.mime.address.strict");
+            System.clearProperty("mail.mime.allowutf8");
+        }
+    }
+
+    @Test
+    public void testSystemPropertiesAndSessionWithNoProperties() throws Exception {
+        try {
+            System.setProperty("mail.mime.address.strict", Boolean.FALSE.toString());
+            System.setProperty("mail.mime.allowutf8", Boolean.TRUE.toString());
+            Session session = Session.getInstance(new Properties());
+            MimeMessage message = new MimeMessage(session);
+            // System properties are ignored when Session is present (even if empty)
+            assertEquals(true, message.isStrict());
+            assertEquals(false, message.isAllowutf8());
+        } finally {
+            System.clearProperty("mail.mime.address.strict");
+            System.clearProperty("mail.mime.allowutf8");
+        }
+    }
+}

--- a/doc/release/CHANGES.txt
+++ b/doc/release/CHANGES.txt
@@ -22,6 +22,7 @@ longer available.
       CHANGES IN THE 2.1.5 RELEASE
       ----------------------------
 E  752 Inconsistent MailMessage contentId property
+E  758 Improve MimeMessage UTF8 handling
 E  789 Only one META-INF/javamail.providers resource file is processed
 
       CHANGES IN THE 2.1.4 RELEASE


### PR DESCRIPTION
CHANGES.txt in master contains the next in CHANGES IN THE 2.2.0 RELEASE:
`E  758 Improve MimeMessage UTF8 handling `

Meanwhile in this branch, it is in CHANGES IN THE 2.1.5 RELEASE.

We will have to modify master to move it under `CHANGES IN THE 2.1.5 RELEASE` section.
