### PR TITLE
WIP: Use a JDK build with recent TLS.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,11 +70,10 @@ spec:
       steps {
         container('mail-ci') {
           sh """
-            wget 'https://download.java.net/openjdk/jdk11/ri/openjdk-11+28_linux-x64_bin.tar.gz' -O openjdk-11.tar.gz -q
-            tar -xzf openjdk-11.tar.gz
-            cd jdk-11
-            export JAVA_HOME=`pwd`
-            cd ..
+            wget -q 'https://api.adoptium.net/v3/binary/latest/11/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk' -O jdk.tgz
+            mkdir jdk && tar -xzf jdk.tgz -C jdk --strip-components=1
+            export JAVA_HOME=${WORKSPACE}/jdk
+            export MAVEN_OPTS="-Dfile.encoding=UTF-8 \${MAVEN_OPTS:-}"
             bash -x ${WORKSPACE}/docker/build_jakartamail.sh
           """
           archiveArtifacts artifacts: '**/target/*.jar'


### PR DESCRIPTION
Pull request #833 [failed in CI](https://ci.eclipse.org/mail/job/mail/job/PR-833/2/stages/); the root cause appears to be that the JDK used in Jenkinsfile is many years old and its TLS doesn't interoperate well with that of post-2024 maven repos. This switches to a recent Temurin build, which seems to work better (but I've marked this WIP so CI won't spam maintainers if I'm wrong).

As a bonus, it tells the CI to use UTF-8, which is important to many of the new tests in #833. It seems to me that the pom.xml setting should be enough, but what do I know.